### PR TITLE
Remove recording retention banner from Past Classes page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ public/sitemap.xml
 
 # testing api
 src/app/api/public/test/route.ts
+CLAUDE.md

--- a/src/app/(app)/components/past-sessions/PastSessions.tsx
+++ b/src/app/(app)/components/past-sessions/PastSessions.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { Alert, AlertDescription } from '../base-v2/ui/Alert';
 import { Input } from '../base-v2/ui/Input';
-import { Info, Search, X } from 'lucide-react';
+import { Search } from 'lucide-react';
 import PastSessionCard from './PastSessionCard';
 import { PastSession } from '~/lib/sessions/types/session-v2';
 import { DateRangePicker } from '@heroui/date-picker';
@@ -34,7 +33,6 @@ const PastSessions = ({
   allSessionData: PastSession[];
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
-  const [isAlertVisible, setIsAlertVisible] = useState(true);
   const [dateRange, setDateRange] = useState<DateRange | null>(null); // Default range is null
 
   const [pastSessionTableData, setPastSessionTableData] = useState<
@@ -170,29 +168,6 @@ const PastSessions = ({
               Clear
             </button>
           </div>
-        </div>
-
-        <div>
-          {/* Alert with a close button */}
-          <Alert
-            className="bg-blue-50 border-blue-200 relative"
-            hidden={!isAlertVisible} // Hide the alert based on state
-          >
-            <div className="flex items-center">
-              <Info className="h-4 w-4 text-blue-600" />
-              <AlertDescription className="text-blue-700 ml-2">
-                Recordings are available for 30 days after the class. Make sure
-                to download important recordings.
-              </AlertDescription>
-            </div>
-            {/* Close button */}
-            <button
-              onClick={() => setIsAlertVisible(false)} // Hide the alert on click
-              className="absolute top-2 right-2 p-1 rounded-full hover:bg-blue-100 transition-colors"
-            >
-              <X className="h-4 w-4 text-blue-600" /> {/* "X" icon */}
-            </button>
-          </Alert>
         </div>
       </div>
       {/* Sessions List */}


### PR DESCRIPTION
## Summary
- Removed the banner that displays "Recordings are available for 30 days after the class" from the Past Classes page
- Cleaned up unused state variable and imports related to the alert component
- Improved the UI by removing unnecessary visual clutter

## Changes Made
- Removed `isAlertVisible` state variable from PastSessions component
- Removed the Alert component displaying the 30-day recording message
- Cleaned up unused imports: Alert, AlertDescription, Info, and X icons

## Test plan
- [x] Verify Past Classes page loads without the banner
- [x] Ensure search and date filtering functionality still works correctly
- [x] Check that no console errors are present after the changes

🤖 Generated with [Claude Code](https://claude.ai/code)