### PR TITLE
Improve session editing UX: rename to lesson topic, remove description, add live updates

### DIFF
--- a/src/app/(app)/components/admin/dashboard/AdminSessionCard.tsx
+++ b/src/app/(app)/components/admin/dashboard/AdminSessionCard.tsx
@@ -61,14 +61,12 @@ const AdminSessionCard: React.FC<UpcommingSessionCardProps> = ({
   const [materialDescription, setMaterialDescription] = useState('');
   const [lessonDetails, setLessonDetails] = useState<LessonDetails>({
     title: sessionData.lessonTitle || '',
-    description: sessionData.lessonDescription || '',
   });
 
   // Store original lesson details to track changes
   const [originalLessonDetails, setOriginalLessonDetails] =
     useState<LessonDetails>({
       title: sessionData.lessonTitle || '',
-      description: sessionData.lessonDescription || '',
     });
 
   const [showEditSessionDialog, setShowSessionEditDialog] = useState(false);
@@ -91,7 +89,6 @@ const AdminSessionCard: React.FC<UpcommingSessionCardProps> = ({
       // Update original lesson details to reflect the saved state
       setOriginalLessonDetails({
         title: lessonDetails.title,
-        description: lessonDetails.description,
       });
     } else {
       toast({
@@ -226,7 +223,6 @@ const AdminSessionCard: React.FC<UpcommingSessionCardProps> = ({
                     <h3 className="text-lg font-medium">
                       {lessonDetails.title}
                     </h3>
-                    <p className="text-gray-600">{lessonDetails.description}</p>
                     <Button
                       variant="ghost"
                       size="sm"
@@ -352,13 +348,25 @@ const AdminSessionCard: React.FC<UpcommingSessionCardProps> = ({
         sessionId={sessionData.id}
         sessionData={{
           title: sessionData?.sessionRawData?.title || '',
-          description: sessionData?.sessionRawData?.description || '',
           startTime: sessionData.start_time || '',
           endTime: sessionData.end_time || '',
           meetingUrl: sessionData?.sessionRawData?.meeting_url || '',
           materials: sessionData?.materials || [],
         }}
         loading={editSessionLoading}
+        onSuccess={(updatedData) => {
+          // Update local lesson details state when title changes
+          if (updatedData.title !== undefined) {
+            setLessonDetails(prev => ({
+              ...prev,
+              title: updatedData.title!
+            }));
+            setOriginalLessonDetails(prev => ({
+              ...prev,
+              title: updatedData.title!
+            }));
+          }
+        }}
       />{' '}
       <AddLessonDetailsDialog
         open={showLessonDetailsDialog}
@@ -366,7 +374,6 @@ const AdminSessionCard: React.FC<UpcommingSessionCardProps> = ({
           // Reset to the last saved state, not the original session data
           setLessonDetails({
             title: originalLessonDetails.title,
-            description: originalLessonDetails.description,
           });
           setShowLessonDetailsDialog(false);
         }}

--- a/src/app/(app)/components/upcoming-sessions/AddLessonDetailsDialog.tsx
+++ b/src/app/(app)/components/upcoming-sessions/AddLessonDetailsDialog.tsx
@@ -2,11 +2,8 @@
 
 import React from 'react';
 import { Input } from '../base-v2/ui/Input';
-import { Textarea } from '../base-v2/ui/Textarea';
 import {
   BookOpen,
-  BookMarked,
-  ListChecks,
 } from 'lucide-react';
 import BaseDialog from '../base-v2/BaseDialog';
 import Label from '~/core/ui/Label';
@@ -39,8 +36,7 @@ const AddLessonDetailsDialog: React.FC<Props> = ({
     if (!originalLessonDetails) return true; // Allow saving if no original state
     
     return (
-      lessonDetails.title !== (originalLessonDetails.title || '') ||
-      lessonDetails.description !== (originalLessonDetails.description || '')
+      lessonDetails.title !== (originalLessonDetails.title || '')
     );
   };
 
@@ -61,7 +57,7 @@ const AddLessonDetailsDialog: React.FC<Props> = ({
           <div className="space-y-2">
             <Label htmlFor="topic" className="flex items-center gap-2">
               <BookOpen size={16} className="text-primary-blue-600" />
-              Topic
+              Lesson Topic
             </Label>
             <Input
               value={lessonDetails?.title || ''}
@@ -71,28 +67,9 @@ const AddLessonDetailsDialog: React.FC<Props> = ({
                   title: e.target.value,
                 })
               }
-              placeholder="Enter the lesson title..."
+              placeholder="Enter the lesson topic..."
               className="w-full"
               id="topic"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="description" className="flex items-center gap-2">
-              <ListChecks size={16} className="text-primary-blue-600" />
-              Lesson Description
-            </Label>
-            <Textarea
-              id="description"
-              value={lessonDetails?.description || ''}
-              onChange={(e) =>
-                setLessonDetails({
-                  ...lessonDetails,
-                  description: e.target.value,
-                })
-              }
-              placeholder="Enter the lesson description..."
-              className="w-full"
-              rows={4}
             />
           </div>
         </div>

--- a/src/app/(app)/components/upcoming-sessions/EditSessionDialog.tsx
+++ b/src/app/(app)/components/upcoming-sessions/EditSessionDialog.tsx
@@ -2,9 +2,6 @@
 
 import React, { useState, useEffect, useTransition } from 'react';
 import { Input } from '../base-v2/ui/Input';
-import { Textarea } from '../base-v2/ui/Textarea';
-import { AlertTriangle } from 'lucide-react';
-import { Alert, AlertDescription } from '../base-v2/ui/Alert';
 import BaseDialog from '../base-v2/BaseDialog';
 import useCsrfToken from '~/core/hooks/use-csrf-token';
 import { Button } from '../base-v2/ui/Button';
@@ -22,7 +19,6 @@ interface Material {
 
 interface EditSessionData {
   title: string;
-  description: string;
   startTime: string;
   endTime: string;
   materials: Material[];
@@ -35,6 +31,7 @@ interface EditSessionDialogProps {
   sessionId: string;
   sessionData: EditSessionData;
   loading?: boolean;
+  onSuccess?: (updatedData: { title?: string }) => void;
 }
 
 const EditSessionDialog: React.FC<EditSessionDialogProps> = ({
@@ -43,6 +40,7 @@ const EditSessionDialog: React.FC<EditSessionDialogProps> = ({
   sessionId,
   sessionData,
   loading = false,
+  onSuccess,
 }) => {
   const [isPending, startTransition] = useTransition();
   const csrfToken = useCsrfToken();
@@ -50,7 +48,6 @@ const EditSessionDialog: React.FC<EditSessionDialogProps> = ({
 
   const [editedSession, setEditedSession] = useState<EditSessionData>({
     title: '',
-    description: '',
     startTime: '',
     endTime: '',
     materials: [],
@@ -67,7 +64,6 @@ const EditSessionDialog: React.FC<EditSessionDialogProps> = ({
     if (sessionData) {
       setEditedSession({
         title: sessionData.title || '',
-        description: sessionData.description || '',
         startTime: sessionData.startTime || '',
         endTime: sessionData.endTime || '',
         materials: sessionData.materials || [],
@@ -134,7 +130,6 @@ const EditSessionDialog: React.FC<EditSessionDialogProps> = ({
   useEffect(() => {
     if (
       editedSession.title !== sessionData.title ||
-      editedSession.description !== sessionData.description ||
       editedSession.startTime !== sessionData.startTime ||
       editedSession.endTime !== sessionData.endTime ||
       editedSession.materials.length !== sessionData.materials.length ||
@@ -146,7 +141,6 @@ const EditSessionDialog: React.FC<EditSessionDialogProps> = ({
     }
   }, [
     editedSession.title,
-    editedSession.description,
     editedSession.startTime,
     editedSession.endTime,
     editedSession.materials.length,
@@ -195,6 +189,11 @@ const EditSessionDialog: React.FC<EditSessionDialogProps> = ({
         });
 
         if (result.success) {
+          // Call onSuccess callback with updated data before closing
+          if (onSuccess && updatedSession.title !== sessionData.title) {
+            onSuccess({ title: updatedSession.title });
+          }
+          
           onClose();
           toast({
             title: 'Success',
@@ -231,29 +230,15 @@ const EditSessionDialog: React.FC<EditSessionDialogProps> = ({
       >
         <div className="space-y-4">
           <div>
-            <label className="text-sm font-medium">Session Title</label>
+            <label className="text-sm font-medium">Lesson Topic</label>
             <Input
-              placeholder="Enter session title"
+              placeholder="Enter lesson topic"
               value={editedSession.title}
               onChange={(e) =>
                 setEditedSession({ ...editedSession, title: e.target.value })
               }
             />
           </div>
-          <div>
-            <label className="text-sm font-medium">Description</label>
-            <Textarea
-              placeholder="Describe what will be covered in this session..."
-              value={editedSession.description}
-              onChange={(e) =>
-                setEditedSession({
-                  ...editedSession,
-                  description: e.target.value,
-                })
-              }
-              className="h-24"
-            />
-          </div>{' '}
           <div className="flex justify-between items-center">
             <label className="text-sm font-medium">Session Date</label>
             <TimezoneIndicator showIcon={false} className="text-xs" />
@@ -282,13 +267,6 @@ const EditSessionDialog: React.FC<EditSessionDialogProps> = ({
               />
             </div>
           </div>
-          <Alert className="bg-yellow-50 border-yellow-200">
-            <AlertTriangle className="h-4 w-4 text-yellow-600" />
-            <AlertDescription className="text-yellow-700">
-              Changes to the session details will affect all enrolled students.
-              Make sure to notify them of any changes.
-            </AlertDescription>
-          </Alert>
         </div>
       </BaseDialog>
     </>

--- a/src/app/(app)/components/upcoming-sessions/UpcommingSessionCard.tsx
+++ b/src/app/(app)/components/upcoming-sessions/UpcommingSessionCard.tsx
@@ -75,7 +75,6 @@ const UpcommingSessionCard: React.FC<UpcommingSessionCardProps> = ({
   const [materialDescription, setMaterialDescription] = useState('');
   const [lessonDetails, setLessonDetails] = useState<LessonDetails>({
     title: sessionData?.sessionRawData?.title || '',
-    description: sessionData?.sessionRawData?.description || '',
   });
 
   const { toast } = useToast();
@@ -84,7 +83,6 @@ const UpcommingSessionCard: React.FC<UpcommingSessionCardProps> = ({
   const [originalLessonDetails, setOriginalLessonDetails] =
     useState<LessonDetails>({
       title: sessionData?.sessionRawData?.title || '',
-      description: sessionData?.sessionRawData?.description || '',
     });
 
   const [showEditSessionDialog, setShowSessionEditDialog] = useState(false);
@@ -165,7 +163,6 @@ const UpcommingSessionCard: React.FC<UpcommingSessionCardProps> = ({
         // Update original lesson details to reflect the saved state
         setOriginalLessonDetails({
           title: lessonDetails.title,
-          description: lessonDetails.description,
         });
       }
     } catch (error) {
@@ -253,9 +250,6 @@ const UpcommingSessionCard: React.FC<UpcommingSessionCardProps> = ({
                 ) : (
                   <div className="space-y-2 bg-gray-50 p-3 rounded-lg">
                     <h3 className="font-medium">{lessonDetails.title}</h3>
-                    <p className="text-gray-600 text-sm">
-                      {lessonDetails.description}
-                    </p>
                     <Button
                       variant="ghost"
                       size="sm"
@@ -433,13 +427,25 @@ const UpcommingSessionCard: React.FC<UpcommingSessionCardProps> = ({
         sessionId={sessionData.id}
         sessionData={{
           title: sessionData.lessonTitle || '',
-          description: sessionData.lessonDescription || '',
           startTime: sessionData.start_time || '',
           endTime: sessionData.end_time || '',
           meetingUrl: sessionData.zoomLinkStudent || '',
           materials: sessionData.materials || [],
         }}
         loading={editSessionLoading}
+        onSuccess={(updatedData) => {
+          // Update local lesson details state when title changes
+          if (updatedData.title !== undefined) {
+            setLessonDetails(prev => ({
+              ...prev,
+              title: updatedData.title!
+            }));
+            setOriginalLessonDetails(prev => ({
+              ...prev,
+              title: updatedData.title!
+            }));
+          }
+        }}
       />
       <AddLessonDetailsDialog
         open={showLessonDetailsDialog}
@@ -447,7 +453,6 @@ const UpcommingSessionCard: React.FC<UpcommingSessionCardProps> = ({
           // Reset to the last saved state, not the original session data
           setLessonDetails({
             title: originalLessonDetails.title,
-            description: originalLessonDetails.description,
           });
           setShowLessonDetailsDialog(false);
         }}

--- a/src/lib/sessions/types/upcoming-sessions.ts
+++ b/src/lib/sessions/types/upcoming-sessions.ts
@@ -58,13 +58,11 @@ interface EditingLessonState {
 interface LessonDetailsState {
   [key: number]: {
     title: string;
-    description: string;
   };
 }
 
 interface LessonDetails {
   title: string;
-  description: string;
 }
 
 interface MaterialUploadDialogProps {


### PR DESCRIPTION
## Summary
This PR improves the user experience for session editing by standardizing terminology, removing unnecessary fields, and implementing live updates to prevent the need for page reloads.

## Changes Made

### 🏷️ Terminology Standardization
- **Renamed "Session Title" to "Lesson Topic"** in EditSessionDialog
- **Renamed "Topic" to "Lesson Topic"** in AddLessonDetailsDialog for consistency
- Both dialogs now use the same terminology for better UX

### 🗑️ Field Cleanup
- **Removed description field** from both EditSessionDialog and AddLessonDetailsDialog
- **Updated LessonDetails interface** to only include the title field
- **Removed warning message** from EditSessionDialog for cleaner UI

### ⚡ Live Updates Implementation
- **Added onSuccess callback** to EditSessionDialog to notify parent components when changes are saved
- **Updated UpcommingSessionCard and AdminSessionCard** to handle live lesson topic updates
- **Fixed issue where lesson topic changes required page reload** to be visible in the card
- Lesson topics now update immediately after editing without requiring a refresh

## Test Plan
1. Open EditSessionDialog and change the lesson topic
2. Save changes - verify the topic updates immediately in the card
3. Verify the same behavior works in admin dashboard
4. Confirm no description fields are present in either dialog
5. Check that both dialogs use consistent "Lesson Topic" labeling

## Screenshots
- ✅ EditSessionDialog now shows "Lesson Topic" instead of "Session Title"
- ✅ Description field removed from both dialogs
- ✅ Warning message removed for cleaner interface
- ✅ Live updates work without page reload

🤖 Generated with [Claude Code](https://claude.ai/code)