### PR TITLE
Fix timezone issue in class registration page

### DIFF
--- a/src/app/(site)/self-registration/page.tsx
+++ b/src/app/(site)/self-registration/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from '~/app/(app)/components/base-v2/ui/Card';
 import { ClassRegistrationData } from '~/lib/classes/types/class-v2';
 import { PublicNextSessionResponse } from '~/lib/sessions/types/session-v2';
 import { formatToHumanReadableDate, formatToLocalHHmmAMPM } from '~/lib/utils/date-utils';
+import { formatToLocalTime } from '~/lib/utils/timezone-utils';
 
 interface SearchParams {
   classId: string;
@@ -93,7 +94,7 @@ export default async function RegisterPage({
 
               <div className="flex items-center text-gray-600">
                 <Clock className="w-4 h-4 mr-2 flex-shrink-0" />
-                {formatToLocalHHmmAMPM(classRegistrationData?.start_time!) + ' - ' + formatToLocalHHmmAMPM(classRegistrationData?.end_time!)}
+                {formatToLocalTime(classRegistrationData?.start_time!, 'h:mm a') + ' - ' + formatToLocalTime(classRegistrationData?.end_time!, 'h:mm a')}
               </div>  
 
               <div className="bg-blue-50 border border-blue-100 rounded-xl p-4">
@@ -112,7 +113,7 @@ export default async function RegisterPage({
           classData={classData}
           nextSessionId={classRegistrationData?.id!}
           formattedDate={classRegistrationData ? formatToHumanReadableDate(classRegistrationData.start_time!) : undefined}
-          formattedTime={classRegistrationData ? formatToLocalHHmmAMPM(classRegistrationData.start_time!) + ' - ' + formatToLocalHHmmAMPM(classRegistrationData.end_time!) : undefined}
+          formattedTime={classRegistrationData ? formatToLocalTime(classRegistrationData.start_time!, 'h:mm a') + ' - ' + formatToLocalTime(classRegistrationData.end_time!, 'h:mm a') : undefined}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
Fixed incorrect time display in the student class registration page where session times were showing in UTC instead of the user's local timezone. For example, a session scheduled for 7:00 PM was incorrectly displaying as 1:30 PM.

## Changes
- Updated `src/app/(site)/self-registration/page.tsx` to use timezone-aware `formatToLocalTime` function instead of `formatToLocalHHmmAMPM`
- Added import for `formatToLocalTime` from timezone utilities
- Fixed time display in both the class information card and the form props

## Test plan
- [ ] Verify class registration page displays correct local times
- [ ] Test with different timezones to ensure proper conversion
- [ ] Confirm time format remains user-friendly (e.g., "7:00 PM - 10:00 PM")

🤖 Generated with [Claude Code](https://claude.ai/code)