### PR TITLE
Add success banner for payment receipt upload

### DIFF
--- a/src/app/(app)/components/student-payments/PaymentDialog.tsx
+++ b/src/app/(app)/components/student-payments/PaymentDialog.tsx
@@ -21,6 +21,7 @@ import { uploadPaymentSlipAction } from '~/lib/student-payments/server-actions';
 import { getFileBuffer } from '~/lib/utils/upload-material-utils';
 import { SessionStudentTableData } from '~/lib/sessions/types/upcoming-sessions';
 import getLogger from '~/core/logger';
+import { useToast } from '~/app/(app)/lib/hooks/use-toast';
 
 interface UploadingFile {
   file: File;
@@ -45,6 +46,7 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
   onPaymentSuccess,
 }) => {
   const csrfToken = useCsrfToken();
+  const { toast } = useToast();
   const [uploadingFile, setUploadingFile] = useState<UploadingFile | null>(
     null,
   );
@@ -213,12 +215,19 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
             : null,
         );
 
+        // Show success toast
+        toast({
+          variant: 'success',
+          title: 'Receipt Submitted Successfully',
+          description: 'Your payment receipt has been submitted for admin approval.',
+        });
+
         // Call the success callback to update parent state
         if (onPaymentSuccess) {
           onPaymentSuccess();
         }
 
-        // Show success message and close dialog after delay
+        // Close dialog after delay
         setTimeout(() => {
           onClose();
         }, 2000);


### PR DESCRIPTION
## Summary
- Added success toast notification when students upload payment receipts
- Integrated with existing base-v2 toast system for consistent UI/UX
- Provides clear feedback that receipt was submitted for admin approval

## Changes Made
- Import and use `useToast` hook in PaymentDialog component
- Display green success banner with title "Receipt Submitted Successfully"
- Include descriptive message indicating admin approval is pending
- Maintain all existing functionality and error handling

## Test Plan
- [x] Verify toast notification appears after successful receipt upload
- [x] Confirm existing success message below upload button still works
- [x] Ensure dialog closes after 2 seconds as before
- [x] Check that error handling remains intact
- [x] Validate TypeScript compilation passes
- [x] Confirm ESLint passes with no new issues

🤖 Generated with [Claude Code](https://claude.ai/code)