### PR TITLE
Add password visibility toggle to sign in and sign up forms

### DIFF
--- a/src/app/auth/components/EmailPasswordSignInForm.tsx
+++ b/src/app/auth/components/EmailPasswordSignInForm.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import Link from 'next/link';
 
 import TextField from '~/core/ui/TextField';
+import PasswordInput from '~/core/ui/PasswordInput';
 import Button from '~/core/ui/Button';
 import If from '~/core/ui/If';
 
@@ -41,10 +42,9 @@ const EmailPasswordSignInForm: React.FCC<{
         <TextField>
           <TextField.Label  className='mb-1.5 block text-xs sm:text-sm font-medium text-gray-700'>
             Password
-            <TextField.Input
+            <PasswordInput
               required
               data-cy={'password-input'}
-              type="password"
               placeholder={''}
               {...passwordControl}
               className='text-sm sm:text-base'

--- a/src/app/auth/components/EmailPasswordSignUpForm.tsx
+++ b/src/app/auth/components/EmailPasswordSignUpForm.tsx
@@ -2,6 +2,7 @@ import { useForm } from 'react-hook-form';
 import { useEffect } from 'react';
 
 import TextField from '~/core/ui/TextField';
+import PasswordInput from '~/core/ui/PasswordInput';
 import Button from '~/core/ui/Button';
 import If from '~/core/ui/If';
 import { filterNameInput } from '~/core/utils/input-filters';
@@ -248,11 +249,10 @@ const EmailPasswordSignUpForm: React.FCC<{
           <TextField>
             <TextField.Label className="mb-1.5 block text-xs sm:text-sm font-medium text-gray-700">
               Password
-              <TextField.Input
+              <PasswordInput
                 {...passwordControl}
                 data-cy={'password-input'}
                 required
-                type="password"
                 placeholder={''}
                 autoComplete="new-password"
                 className="text-sm sm:text-base"
@@ -270,11 +270,10 @@ const EmailPasswordSignUpForm: React.FCC<{
           <TextField>
             <TextField.Label className="mb-1.5 block text-xs sm:text-sm font-medium text-gray-700">
               Repeat Password
-              <TextField.Input
+              <PasswordInput
                 {...repeatPasswordControl}
                 data-cy={'repeat-password-input'}
                 required
-                type="password"
                 placeholder={''}
                 autoComplete="new-password"
                 className="text-sm sm:text-base"

--- a/src/core/ui/PasswordInput.tsx
+++ b/src/core/ui/PasswordInput.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React, { forwardRef, useState } from 'react';
+import classNames from 'clsx';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+
+type Props = React.InputHTMLAttributes<HTMLInputElement> & {
+  className?: string;
+};
+
+const PasswordInput = forwardRef<HTMLInputElement, Props>(
+  function PasswordInputComponent({ className, ...props }, ref) {
+    const [showPassword, setShowPassword] = useState(false);
+
+    const togglePasswordVisibility = () => {
+      setShowPassword(!showPassword);
+    };
+
+    return (
+      <div className="relative">
+        <input
+          {...props}
+          type={showPassword ? 'text' : 'password'}
+          className={classNames(
+            'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+            className,
+          )}
+          ref={ref}
+        />
+        <button
+          type="button"
+          className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+          onClick={togglePasswordVisibility}
+          tabIndex={-1}
+        >
+          {showPassword ? (
+            <EyeSlashIcon className="h-5 w-5" aria-hidden="true" />
+          ) : (
+            <EyeIcon className="h-5 w-5" aria-hidden="true" />
+          )}
+        </button>
+      </div>
+    );
+  },
+);
+
+export default PasswordInput;


### PR DESCRIPTION
## Summary
- Create reusable PasswordInput component with eye icon toggle using Heroicons
- Update EmailPasswordSignInForm to use PasswordInput component  
- Update EmailPasswordSignUpForm to use PasswordInput for both password fields

## Test plan
- [ ] Test sign in form password visibility toggle works correctly
- [ ] Test sign up form password visibility toggle works for both password fields
- [ ] Verify form validation still works properly
- [ ] Test accessibility of toggle buttons
- [ ] Verify styling matches existing design system

🤖 Generated with [Claude Code](https://claude.ai/code)