### PR TITLE
Fix dashboard greeting to use user's timezone

### DIFF
--- a/src/app/(app)/components/TimezoneGreeting.tsx
+++ b/src/app/(app)/components/TimezoneGreeting.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Sun, Moon } from 'lucide-react';
+
+interface TimezoneGreetingProps {
+  userName: string;
+}
+
+export default function TimezoneGreeting({ userName }: TimezoneGreetingProps) {
+  const [greeting, setGreeting] = useState<{
+    text: string;
+    icon: typeof Sun;
+  } | null>(null);
+
+  useEffect(() => {
+    const updateGreeting = () => {
+      const hour = new Date().getHours();
+      if (hour < 12) {
+        setGreeting({ text: 'Good morning', icon: Sun });
+      } else if (hour < 18) {
+        setGreeting({ text: 'Good afternoon', icon: Sun });
+      } else {
+        setGreeting({ text: 'Good evening', icon: Moon });
+      }
+    };
+
+    updateGreeting();
+    // Update greeting every minute in case the user keeps the page open across time boundaries
+    const interval = setInterval(updateGreeting, 60000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!greeting) {
+    // Return a placeholder while loading to prevent layout shift
+    return (
+      <div className="flex items-center space-x-2">
+        <Sun className="h-6 w-6 text-yellow-500" />
+        <span>Loading...</span>
+      </div>
+    );
+  }
+
+  const { text, icon: GreetingIcon } = greeting;
+
+  return (
+    <div className="flex items-center space-x-2">
+      <GreetingIcon className="h-6 w-6 text-yellow-500" />
+      <span>{text}, {userName}</span>
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -13,23 +13,13 @@ import StudentDashboard from '../components/student-dashboard/StudentDashboard';
 import TutorDBClient from '../components/tutor-dashboard/TutorDashBoardClient';
 import AdminDashboardClient from '../components/admin/dashboard/AdminDashboardClient';
 import UnauthorizedAccessToast from '../components/UnauthorizedAccessToast';
+import TimezoneGreeting from '../components/TimezoneGreeting';
 import { getTutorDashboardDataAction } from '~/lib/tutorStats/server-action';
-import { Sun, Moon } from 'lucide-react';
 
 export const metadata = {
   title: 'Dashboard',
 };
 
-function getTimeBasedGreeting() {
-  const hour = new Date().getHours();
-  if (hour < 12) {
-    return { greeting: 'Good morning', icon: Sun };
-  } else if (hour < 18) {
-    return { greeting: 'Good afternoon', icon: Sun };
-  } else {
-    return { greeting: 'Good evening', icon: Moon };
-  }
-}
 
 async function DashboardPage() {
   const client = getSupabaseServerComponentClient();
@@ -91,14 +81,8 @@ async function DashboardPage() {
       }
 
       // Generate dynamic greeting for tutor
-      const { greeting, icon: GreetingIcon } = getTimeBasedGreeting();
       const tutorName = userData.first_name ? `${userData.first_name}` : 'Tutor';
-      const dynamicTitle = (
-        <div className="flex items-center space-x-2">
-          <GreetingIcon className="h-6 w-6 text-yellow-500" />
-          <span>{greeting}, {tutorName}</span>
-        </div>
-      );
+      const dynamicTitle = <TimezoneGreeting userName={tutorName} />;
 
       // Render tutor dashboard
       return (
@@ -130,14 +114,8 @@ async function DashboardPage() {
       );
 
       // Generate dynamic greeting for student
-      const { greeting, icon: GreetingIcon } = getTimeBasedGreeting();
       const studentName = userData.first_name ? `${userData.first_name}` : 'Student';
-      const dynamicTitle = (
-        <div className="flex items-center space-x-2">
-          <GreetingIcon className="h-6 w-6 text-yellow-500" />
-          <span>{greeting}, {studentName}</span>
-        </div>
-      );
+      const dynamicTitle = <TimezoneGreeting userName={studentName} />;
 
       // Render student dashboard
       return (


### PR DESCRIPTION
## Summary
- Fixed dashboard greeting to display time-based greetings (Good morning/afternoon/evening) based on user's local timezone instead of server timezone
- Created a new `TimezoneGreeting` client component that runs in the browser to access user's local time
- Replaced server-side greeting logic in dashboard page for both tutor and student roles
- Added proper loading state to prevent layout shift during component hydration
- Included automatic updates every minute to keep greeting current

## Changes Made
- **New file**: `src/app/(app)/components/TimezoneGreeting.tsx` - Client component for timezone-aware greetings
- **Modified**: `src/app/(app)/dashboard/page.tsx` - Updated to use new client component instead of server-side logic

## Test Plan
- [x] Verify greeting displays correctly for users in different timezones
- [x] Check that loading state prevents layout shift
- [x] Confirm TypeScript compilation passes
- [x] Test that greeting updates automatically when time boundaries are crossed

🤖 Generated with [Claude Code](https://claude.ai/code)