### PR TITLE
Fix recording URL handling in past classes cards

### DIFF
--- a/src/app/(app)/components/student-dashboard/StudentSessionCard.tsx
+++ b/src/app/(app)/components/student-dashboard/StudentSessionCard.tsx
@@ -76,10 +76,17 @@ const StudentSessionCard = ({
   };
 
   const getRecordingUrl = useCallback(
-    async (fileName: string): Promise<string> => {
-      console.log('Fetching signed URL for:', fileName);
+    async (urlOrFileName: string): Promise<string> => {
+      // Check if the input is already a full URL
+      if (urlOrFileName.startsWith('http://') || urlOrFileName.startsWith('https://')) {
+        // If it's already a full URL, return it directly
+        return urlOrFileName;
+      }
+      
+      // Otherwise, treat it as a filename and get a signed URL
+      console.log('Fetching signed URL for:', urlOrFileName);
       const response = await fetch(
-        `/api/signed-url?fileName=${encodeURIComponent(fileName)}`,
+        `/api/signed-url?fileName=${encodeURIComponent(urlOrFileName)}`,
       );
       if (!response.ok) {
         throw new Error(`Failed to fetch signed URL: ${response.statusText}`);


### PR DESCRIPTION
## Summary
- Fixed recording URL handling in past classes cards that was causing malformed URLs
- Modified `getRecordingUrl` function to detect full URLs vs filenames and handle appropriately
- Prevents double-encoding of S3 URLs that was breaking recording playback

## Test plan
- [x] Test recording buttons in past classes cards with full S3 URLs
- [x] Verify backward compatibility with filename-only URLs
- [x] Confirm recording playback works in both card and detail views

🤖 Generated with [Claude Code](https://claude.ai/code)