### PR TITLE
Redirect non-enrolled students to registration page

### DIFF
--- a/src/app/(app)/sessions/student/[sessionId]/page.tsx
+++ b/src/app/(app)/sessions/student/[sessionId]/page.tsx
@@ -74,6 +74,19 @@ export default async function SessionViewPage({ params }: Params) {
     sessionData.class_id!,
   );
 
+  // If student is not enrolled in the class, redirect to registration page
+  if (!isStudentEnrolledToClass && classData) {
+    // Build registration URL with class information
+    const registrationUrl = new URL('/self-registration', process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000');
+    registrationUrl.searchParams.set('classId', sessionData.class_id!);
+    registrationUrl.searchParams.set('className', classData.name);
+    registrationUrl.searchParams.set('nextSession', sessionData.start_time || '');
+    registrationUrl.searchParams.set('time', classData.time_slots?.map((slot: any) => `${slot.day}, ${slot.startTime} - ${slot.endTime}`).join('; ') || '');
+    registrationUrl.searchParams.set('tutorName', `${classData.tutor?.first_name || ''} ${classData.tutor?.last_name || ''}`.trim());
+    
+    redirect(registrationUrl.toString());
+  }
+
   // Determine session type based on start time
   const sessionType =
     new Date(sessionData.start_time || '') > new Date() ? 'upcoming' : 'past';


### PR DESCRIPTION
## Summary
- Implements automatic redirect from class join page to registration page when student is not enrolled
- Pre-populates registration form with class details (ID, name, schedule, tutor info)
- Improves user experience by seamlessly guiding non-enrolled students to registration

## Changes Made
- Modified `/src/app/(app)/sessions/student/[sessionId]/page.tsx` to check enrollment status
- Added redirect logic that builds registration URL with class information
- Maintains existing authentication and authorization flows

## Test Plan
- [ ] Test class join flow for enrolled students (should work as before)
- [ ] Test class join flow for non-enrolled students (should redirect to registration)
- [ ] Verify registration page receives correct pre-populated data
- [ ] Confirm TypeScript compilation and linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)